### PR TITLE
chore(docs): audit and fix nav order, titles, and draft visibility

### DIFF
--- a/content/docs/build/api-overview.md
+++ b/content/docs/build/api-overview.md
@@ -2,6 +2,7 @@
 title: "API Overview (Draft)"
 description: "Authentication, base URLs, and core resources."
 nav_order: 2
+nav_display: false
 ---
 
 > Draft placeholder — update once the public API surface is stable.
@@ -14,13 +15,13 @@ nav_order: 2
 
 ## Core resources (planned)
 
-| Resource | Methods | Description |
-| --- | --- | --- |
-| `/outlines` | GET, POST, PATCH | List, create, and update interview outlines. |
-| `/agents` | GET, POST, PATCH | Manage concierge/interviewer/evaluator agents. |
-| `/conversations` | GET | Fetch transcripts, metadata, trust scores. |
-| `/invites` | POST | Trigger invites or send reminders. |
-| `/highlights` | GET, POST | Publish or retrieve highlight pages. |
+| Resource         | Methods          | Description                                    |
+| ---------------- | ---------------- | ---------------------------------------------- |
+| `/outlines`      | GET, POST, PATCH | List, create, and update interview outlines.   |
+| `/agents`        | GET, POST, PATCH | Manage concierge/interviewer/evaluator agents. |
+| `/conversations` | GET              | Fetch transcripts, metadata, trust scores.     |
+| `/invites`       | POST             | Trigger invites or send reminders.             |
+| `/highlights`    | GET, POST        | Publish or retrieve highlight pages.           |
 
 ## Sample request
 

--- a/content/docs/build/automation-recipes.md
+++ b/content/docs/build/automation-recipes.md
@@ -2,6 +2,7 @@
 title: "Automation Recipes (Placeholder)"
 description: "Examples for Zapier/Make, Snowflake syncs, and Slack alerts."
 nav_order: 4
+nav_display: false
 ---
 
 Outline the automations customers ask for most. Fill in step-by-step instructions later.
@@ -14,6 +15,7 @@ Outline the automations customers ask for most. Fill in step-by-step instruction
 4. **Trigger nurture emails when Interviewer tags include "trial".**
 
 For each recipe, document:
+
 - Trigger event (webhook/API call)
 - Transformation/filters
 - Destination app + sample payloads

--- a/content/docs/build/index.md
+++ b/content/docs/build/index.md
@@ -8,9 +8,9 @@ Engineering teams use this section to connect Perspective to their environments.
 
 ## Topics
 
-- [Perspective MCP Server](/docs/build/mcp): install, configure, and use the Model Context Protocol server so Claude Desktop, Cursor, and other MCP-enabled tools can manage agents and interviews.
-- [API Overview](/docs/build/api-overview): base URLs, auth, rate limits, and primary resources (draft).
-- [Webhooks & Automations](/docs/build/webhooks): event payloads, signature verification, and retry behavior (draft).
-- [Automation Recipes](/docs/build/automation-recipes): outline of the most requested Zapier/Make/Snowflake workflows (draft).
+- [Use the Perspective AI MCP](/docs/build/mcp): install, configure, and use the Model Context Protocol server so Claude Desktop, Cursor, and other MCP-enabled tools can manage agents and interviews.
+  <!-- - [API Overview (Draft)](/docs/build/api-overview): base URLs, auth, rate limits, and primary resources (draft). -->
+  <!-- - [Webhooks & Automations](/docs/build/webhooks): event payloads, signature verification, and retry behavior (draft). -->
+  <!-- - [Automation Recipes (Placeholder)](/docs/build/automation-recipes): outline of the most requested Zapier/Make/Snowflake workflows (draft). -->
 
 Looking for usage guidance instead? Head back to the [Guide](/docs/guide). Need structured lessons? Visit [Training](/docs/training).

--- a/content/docs/build/webhooks.md
+++ b/content/docs/build/webhooks.md
@@ -2,17 +2,18 @@
 title: "Webhooks & Automations"
 description: "Subscribe to conversation and highlight events."
 nav_order: 3
+nav_display: false
 ---
 
 > Draft placeholder — verify payloads before publishing externally.
 
 ## Event types
 
-| Event | Trigger |
-| --- | --- |
-| `conversation.completed` | Interview or concierge session ends. |
-| `highlight.published` | A highlight page is set to public or updated. |
-| `trust.alert` | Conversation flagged for low-quality or risky content. |
+| Event                    | Trigger                                                |
+| ------------------------ | ------------------------------------------------------ |
+| `conversation.completed` | Interview or concierge session ends.                   |
+| `highlight.published`    | A highlight page is set to public or updated.          |
+| `trust.alert`            | Conversation flagged for low-quality or risky content. |
 
 ## Configure a webhook endpoint
 
@@ -51,4 +52,4 @@ Verify signatures using `X-Perspective-Signature` header (HMAC-SHA256 of the raw
 - Push concierge leads into HubSpot/CRM.
 - Create Jira tickets when evaluator scores drop below threshold.
 - Trigger Slack alerts for `trust.alert` to let humans review.
-More automation examples are tracked in [Automation Recipes](/docs/build/automation-recipes) (coming soon).
+  More automation examples are tracked in [Automation Recipes](/docs/build/automation-recipes) (coming soon).

--- a/content/docs/examples/customer-stories.md
+++ b/content/docs/examples/customer-stories.md
@@ -2,6 +2,7 @@
 title: "Customer Stories (Draft)"
 description: "Structure for publishing real deployments."
 nav_order: 2
+nav_display: false
 ---
 
 Use this template when turning internal wins into public proof.
@@ -17,9 +18,9 @@ Use this template when turning internal wins into public proof.
 
 ## Pipeline tracker
 
-| Customer | Status | Point person | Assets needed |
-| --- | --- | --- | --- |
-| Healthcare intake pilot | Drafting | Nate | Chart + quote |
-| Legal intake | Needs interview | Guy | Screenshot |
+| Customer                | Status          | Point person | Assets needed |
+| ----------------------- | --------------- | ------------ | ------------- |
+| Healthcare intake pilot | Drafting        | Nate         | Chart + quote |
+| Legal intake            | Needs interview | Guy          | Screenshot    |
 
 Once a story is published, link it here and tag the related use case so readers can jump between inspiration and step-by-step guides.

--- a/content/docs/examples/index.md
+++ b/content/docs/examples/index.md
@@ -2,6 +2,7 @@
 title: "Examples — Use Cases & Playbooks"
 description: "See how teams deploy Perspective across industries and workflows."
 nav_order: 4
+nav_display: false
 ---
 
 Use this section to grab ready-made blueprints. Every example shows the research question, recommended agent setup, and expected outcomes so you can adapt it quickly.
@@ -9,7 +10,7 @@ Use this section to grab ready-made blueprints. Every example shows the research
 ## Explore
 
 - [Use Case Library](/docs/use-cases): 30+ detailed playbooks across Product, CX, Research, Revenue, and Operations teams.
-- [Customer Stories](/docs/examples/customer-stories): draft pipeline + structure for publishing real deployments.
+- [Customer Stories (Draft)](/docs/examples/customer-stories): draft pipeline + structure for publishing real deployments.
 - [Templates & Imports](/docs/examples/templates): placeholder catalog for outlines, prompts, and analysis packs.
 
 Pair these examples with the [Guide](/docs/guide) for execution details or the [Build docs](/docs/build) if a playbook calls for custom integrations.

--- a/content/docs/examples/templates.md
+++ b/content/docs/examples/templates.md
@@ -2,17 +2,18 @@
 title: "Templates & Imports"
 description: "Reusable outlines, prompts, and analysis frameworks."
 nav_order: 3
+nav_display: false
 ---
 
 Draft placeholder for the template gallery.
 
 ## Outline templates
 
-| Name | Agent | Format | Link |
-| --- | --- | --- | --- |
-| Concierge — Healthcare Intake | Concierge | `.json` + instructions | _TODO_ |
-| Interviewer — Churn Post-Mortem | Interviewer | Outline snippet | _TODO_ |
-| Evaluator — Support QA | Evaluator | Rubric | _TODO_ |
+| Name                            | Agent       | Format                 | Link   |
+| ------------------------------- | ----------- | ---------------------- | ------ |
+| Concierge — Healthcare Intake   | Concierge   | `.json` + instructions | _TODO_ |
+| Interviewer — Churn Post-Mortem | Interviewer | Outline snippet        | _TODO_ |
+| Evaluator — Support QA          | Evaluator   | Rubric                 | _TODO_ |
 
 ## Analysis frameworks
 

--- a/content/docs/guide/getting-started/analysis-sessions.md
+++ b/content/docs/guide/getting-started/analysis-sessions.md
@@ -3,7 +3,7 @@ title: "Conduct Analysis Sessions"
 description: "Learn how to quickly extract and share insights from interviews"
 date: "2023-09-16"
 tags: ["getting-started", "analysis session"]
-nav_order: 3
+nav_order: 4
 nav_display: true
 ---
 

--- a/content/docs/guide/getting-started/create-research-outlines.md
+++ b/content/docs/guide/getting-started/create-research-outlines.md
@@ -1,9 +1,9 @@
 ---
-title: "Creating Research Outlines in Perspective AI"
+title: "Creating Research Outlines"
 description: "Learn how to create and refine research outlines that guide Perspective AI to conduct effective user interviews aligned with your research goals."
 date: "2025-10-16"
 tags: ["research-outlines", "interviews", "getting-started", "user-research"]
-nav_order: 1
+nav_order: 2
 nav_display: true
 ---
 
@@ -30,15 +30,17 @@ These questions help you craft a focused research question that generates a usef
 Navigate to the research creation interface and enter a detailed research question. Be specific about who you want to interview and what you want to learn.
 
 **Example format:**
+
 ```
-I want to interview [target audience] about [specific topic] 
+I want to interview [target audience] about [specific topic]
 so that I can learn [desired outcome].
 ```
 
 **Sample question:**
+
 ```
-I want to interview existing customers about their experience using 
-our beta AI feature so that I can learn what we need to improve 
+I want to interview existing customers about their experience using
+our beta AI feature so that I can learn what we need to improve
 before launching.
 ```
 
@@ -55,6 +57,7 @@ Respond to clarifying questions to help the system understand your research obje
 Your generated outline includes several key elements:
 
 ### Research Type
+
 Based on your objectives, Perspective automatically determines the most appropriate research approach:
 
 **Exploratory** – Discovering problems, needs, and opportunities without preconceived solutions
@@ -72,22 +75,29 @@ You don't need to specify the research type—it's determined automatically to e
 **Note:** While the research type is automatically selected based on your goals, you can request a change if needed by telling Perspective which type you prefer. However, we generally don't recommend this, as the automatic classification is designed to match the methodology to your objectives. Only change the research type if you have specific methodological requirements.
 
 ### Description
+
 Clearly states what is being researched and by whom, providing context for the interview.
 
 ### Research Question
+
 The core question formulated to address the key business and user needs identified during planning.
 
 ### Goals
+
 The key objectives derived from your research question. These guide what the interview should accomplish.
 
 ### Participants
+
 A description of the target audience profile, including relevant demographic, behavioral, or firmographic criteria.
 
 ### Interview Guidelines
+
 Define the flow and tone instructions for the AI interviewer. Think of these as guardrails that shape how the interview agent conducts conversations.
 
 ### Optional Components
+
 Research outlines can also include:
+
 - **Mandatory questions** – specific questions that must be asked in every interview
 - **Resources** – reference materials for the interviewer
 - **Form fields** – structured data to collect from participants
@@ -101,6 +111,7 @@ See individual help articles for details on each component.
 After reviewing the initial outline, you can request modifications conversationally. Each change is evaluated and generates a new version of the outline.
 
 **Example changes:**
+
 - "I want to interview enterprise customers specifically"
 - "Add a goal about understanding feature adoption barriers"
 - "Make the interview tone more conversational and less formal"
@@ -108,6 +119,7 @@ After reviewing the initial outline, you can request modifications conversationa
 ### Test the interview yourself
 
 Try the interview as if you were a participant. This hands-on experience often reveals:
+
 - Questions that need clarification
 - Flow issues in the conversation
 - Missing topics or goals

--- a/content/docs/guide/getting-started/index.md
+++ b/content/docs/guide/getting-started/index.md
@@ -8,9 +8,9 @@ Launch your first Perspective program. This section walks through the foundation
 ## In this section
 
 - [Profile Setup](/docs/guide/getting-started/profile-setup)
-- [Create Research Outlines](/docs/guide/getting-started/create-research-outlines)
-- [Invite Participants](/docs/guide/getting-started/invite-participants)
-- [Analyze Interviews](/docs/guide/getting-started/analysis-sessions)
-- [Testing Your Flow](/docs/guide/getting-started/testing)
+- [Creating Research Outlines](/docs/guide/getting-started/create-research-outlines)
+- [Inviting Participants to Your Research](/docs/guide/getting-started/invite-participants)
+- [Conduct Analysis Sessions](/docs/guide/getting-started/analysis-sessions)
+<!-- - [Testing Your Flow](/docs/guide/getting-started/testing) -->
 
 Use these guides to get comfortable with the core product flows before layering on advanced automation.

--- a/content/docs/guide/getting-started/invite-participants.md
+++ b/content/docs/guide/getting-started/invite-participants.md
@@ -3,7 +3,7 @@ title: "Inviting Participants to Your Research"
 description: "Learn how to invite participants to Perspective AI interviews using shareable links or direct email invitations from within the platform."
 date: "2025-11-03"
 tags: ["participants", "invitations", "recruiting", "how-to"]
-nav_order: 2
+nav_order: 3
 nav_display: true
 ---
 

--- a/content/docs/guide/getting-started/profile-setup.md
+++ b/content/docs/guide/getting-started/profile-setup.md
@@ -3,7 +3,7 @@ title: "Profile Setup"
 description: "Learn how to use Perspective AI to gather customer feedback efficiently"
 date: "2024-09-03"
 tags: ["getting-started", "feedback", "research outline"]
-nav_order: 4
+nav_order: 1
 nav_display: true
 ---
 

--- a/content/docs/guide/getting-started/testing.md
+++ b/content/docs/guide/getting-started/testing.md
@@ -1,5 +1,6 @@
 ---
-title: Test Page
+title: Testing Your Flow
+nav_order: 5
 nav_display: false
 ---
 

--- a/content/docs/guide/index.md
+++ b/content/docs/guide/index.md
@@ -8,14 +8,14 @@ Welcome to the Guide. This collection walks product, research, and CX teams thro
 
 ## What you will find here
 
-| Section | Focus |
-| --- | --- |
-| [Orientation](/docs/guide/orientation) | Quick tour of Perspective's architecture, roles, and success checklist. |
-| [Getting Started](/docs/guide/getting-started) | Launch your first study, invite participants, and understand core concepts. |
-| [Running Programs](/docs/guide/running-programs) | Design agents, manage participant groups, and embed interviews in your product. |
-| [Insights](/docs/guide/insights) | Analyze sessions, publish highlights, and monitor trust signals. |
-| [Operations](/docs/guide/operations) | Workspaces, permissions, and governance topics for admins. |
+| Section                                           | Focus                                                                           |
+| ------------------------------------------------- | ------------------------------------------------------------------------------- |
+| [Perspective in an Hour](/docs/guide/orientation) | Quick tour of Perspective's architecture, roles, and success checklist.         |
+| [Getting Started](/docs/guide/getting-started)    | Launch your first study, invite participants, and understand core concepts.     |
+| [Running Programs](/docs/guide/running-programs)  | Design agents, manage participant groups, and embed interviews in your product. |
+| [Insights](/docs/guide/insights)                  | Analyze sessions, publish highlights, and monitor trust signals.                |
+| [Operations](/docs/guide/operations)              | Workspaces, permissions, and governance topics for admins.                      |
 
 Each article links to actionable checklists and workflows so you can move from experimentation to production quickly. If you are looking for developer integrations, jump to the [Build docs](/docs/build). For hands-on lessons and videos, head to [Training](/docs/training).
 
-Looking for product updates? Check [What's New](/docs/guide/whats-new).
+<!-- Looking for product updates? Check [What's New](/docs/guide/whats-new). -->

--- a/content/docs/guide/insights/index.md
+++ b/content/docs/guide/insights/index.md
@@ -6,7 +6,7 @@ nav_order: 3
 Turn raw interviews into decisions. Use these guides to review sessions, validate participants, and publish highlights.
 
 - [Analyze Interviews](/docs/guide/getting-started/analysis-sessions)
-- [Trust Assessment](/docs/guide/insights/trust-assessment)
-- [Public Highlight Pages](/docs/guide/insights/public-highlight-pages)
+- [Trust Assessment: Ensuring Research Integrity Through Participant Validation](/docs/guide/insights/trust-assessment)
+- [Publishing and Sharing Research: Public Highlight Pages Guide](/docs/guide/insights/public-highlight-pages)
 
 Pair this section with the [Training video lessons](/docs/training/lessons/) if you want to watch the workflows end-to-end.

--- a/content/docs/guide/operations/billing.md
+++ b/content/docs/guide/operations/billing.md
@@ -2,6 +2,7 @@
 title: "Billing & Seat Management"
 description: "How Perspective handles plans, seats, and invoices."
 nav_order: 3
+nav_display: false
 ---
 
 Draft guidance for finance/ops while we finalize productized billing docs.
@@ -26,11 +27,11 @@ Draft guidance for finance/ops while we finalize productized billing docs.
 
 ## Forecasting usage
 
-| Metric | Where to find it | Owner |
-| --- | --- | --- |
-| Active agents per workspace | Workspace dashboard | Research ops |
-| Concierge conversation volume | Insights → Dashboards | CX ops |
-| Evaluator scoring volume | Analytics exports | Product ops |
+| Metric                        | Where to find it      | Owner        |
+| ----------------------------- | --------------------- | ------------ |
+| Active agents per workspace   | Workspace dashboard   | Research ops |
+| Concierge conversation volume | Insights → Dashboards | CX ops       |
+| Evaluator scoring volume      | Analytics exports     | Product ops  |
 
 ## Checklist before end of quarter
 

--- a/content/docs/guide/operations/data-governance.md
+++ b/content/docs/guide/operations/data-governance.md
@@ -2,6 +2,7 @@
 title: "Data Retention & Privacy"
 description: "Draft policy for transcripts, highlights, and exports."
 nav_order: 4
+nav_display: false
 ---
 
 Use this page to align legal, security, and research teams on how Perspective data is stored.
@@ -28,11 +29,11 @@ Use this page to align legal, security, and research teams on how Perspective da
 
 ## Incident response basics
 
-| Step | Owner |
-| --- | --- |
-| Identify abnormal access/export | Security/ops monitors | 
-| Lock affected workspace (read-only) | Admin | 
-| Notify legal + impacted customers | Exec sponsor | 
-| Document in incident log | Security | 
+| Step                                | Owner                 |
+| ----------------------------------- | --------------------- |
+| Identify abnormal access/export     | Security/ops monitors |
+| Lock affected workspace (read-only) | Admin                 |
+| Notify legal + impacted customers   | Exec sponsor          |
+| Document in incident log            | Security              |
 
 Fill in the exact owners and tooling once the security team finalizes the playbook.

--- a/content/docs/guide/operations/index.md
+++ b/content/docs/guide/operations/index.md
@@ -5,11 +5,9 @@ nav_order: 4
 
 Handle the administrative side of Perspective: workspaces, access, and billing.
 
-- [Manage Workspaces](/docs/guide/operations/workspaces)
-
-- [Manage Workspaces](/docs/guide/operations/workspaces)
-- [Roles & Permissions](/docs/guide/operations/permissions-roles)
-- [Billing & Seat Management](/docs/guide/operations/billing)
-- [Data Retention & Privacy](/docs/guide/operations/data-governance)
+- [Create and Manage Workspaces](/docs/guide/operations/workspaces)
+<!-- - [Roles & Permissions](/docs/guide/operations/permissions-roles) -->
+<!-- - [Billing & Seat Management](/docs/guide/operations/billing) -->
+<!-- - [Data Retention & Privacy](/docs/guide/operations/data-governance) -->
 
 More operations content is in progress. Let us know which governance topics you need next.

--- a/content/docs/guide/operations/permissions-roles.md
+++ b/content/docs/guide/operations/permissions-roles.md
@@ -2,19 +2,20 @@
 title: "Roles & Permissions"
 description: "Who can edit outlines, launch agents, and access transcripts."
 nav_order: 2
+nav_display: false
 ---
 
 Use this draft to define access policy before handing Perspective to more teams.
 
 ## Default roles
 
-| Role | Capabilities | Recommended owners |
-| --- | --- | --- |
-| **Owner** | Manage billing, create/delete workspaces, generate API/MCP tokens. | Executive sponsor, head of ops. |
-| **Admin** | Invite users, assign roles, edit any outline/agent, view all transcripts. | Research ops, CX ops. |
-| **Builder** | Create/edit outlines, manage agents they own, view insights. | Product managers, researchers. |
-| **Analyst** | View transcripts, highlights, dashboards; cannot change outlines. | Analysts, customer insights. |
-| **Viewer** | Read-only access to highlights/shared dashboards. | Leadership, stakeholders. |
+| Role        | Capabilities                                                              | Recommended owners              |
+| ----------- | ------------------------------------------------------------------------- | ------------------------------- |
+| **Owner**   | Manage billing, create/delete workspaces, generate API/MCP tokens.        | Executive sponsor, head of ops. |
+| **Admin**   | Invite users, assign roles, edit any outline/agent, view all transcripts. | Research ops, CX ops.           |
+| **Builder** | Create/edit outlines, manage agents they own, view insights.              | Product managers, researchers.  |
+| **Analyst** | View transcripts, highlights, dashboards; cannot change outlines.         | Analysts, customer insights.    |
+| **Viewer**  | Read-only access to highlights/shared dashboards.                         | Leadership, stakeholders.       |
 
 Adjust names to match your actual RBAC implementation—this page is the placeholder narrative.
 

--- a/content/docs/guide/running-programs/add-form-fields.md
+++ b/content/docs/guide/running-programs/add-form-fields.md
@@ -3,7 +3,7 @@ title: "Adding Form Fields to Research Outlines"
 description: "Capture standardized information during interviews with form fields that maintain conversational flow while delivering structured, scannable data."
 date: "2025-10-29"
 tags: ["form-fields", "research-outlines", "structured-data", "interviews"]
-nav_order: 1
+nav_order: 2
 nav_display: true
 ---
 

--- a/content/docs/guide/running-programs/completion-flows.md
+++ b/content/docs/guide/running-programs/completion-flows.md
@@ -3,7 +3,7 @@ title: "Creating Completion Flows for Conditional Routing"
 description: "Automatically route participants to different destinations at the end of interviews based on what was discussed, creating personalized next steps."
 date: "2025-11-04"
 tags: ["completion-flows", "conditional-logic", "automation", "wrap-up"]
-nav_order: 6
+nav_order: 4
 nav_display: true
 ---
 

--- a/content/docs/guide/running-programs/create-participant-groups.md
+++ b/content/docs/guide/running-programs/create-participant-groups.md
@@ -3,7 +3,7 @@ title: "Creating and Managing Participant Groups"
 description: "Organize research participants into reusable groups for easier recruiting and longitudinal research tracking across multiple studies."
 date: "2025-11-04"
 tags: ["participant-groups", "recruiting", "organization", "participant-management"]
-nav_order: 2
+nav_order: 9
 nav_display: true
 ---
 

--- a/content/docs/guide/running-programs/creating-concierge-agent.md
+++ b/content/docs/guide/running-programs/creating-concierge-agent.md
@@ -3,7 +3,7 @@ title: "Creating a Concierge Agent"
 description: "Build intelligent conversational experiences that efficiently collect structured information by inferring what they can and only asking what they must."
 date: "2025-11-04"
 tags: ["concierge-agent", "forms", "data-collection", "how-to"]
-nav_order: 9
+nav_order: 7
 nav_display: true
 ---
 

--- a/content/docs/guide/running-programs/creating-evaluator-agent.md
+++ b/content/docs/guide/running-programs/creating-evaluator-agent.md
@@ -3,7 +3,7 @@ title: "Creating an Evaluator Agent"
 description: "Transform boring surveys into engaging conversations that collect quantitative metrics while maintaining the warmth of qualitative research."
 date: "2025-11-04"
 tags: ["evaluator-agent", "surveys", "feedback", "how-to"]
-nav_order: 10
+nav_order: 8
 nav_display: true
 ---
 

--- a/content/docs/guide/running-programs/creating-interviewer-agent.md
+++ b/content/docs/guide/running-programs/creating-interviewer-agent.md
@@ -3,7 +3,7 @@ title: "Creating an Interviewer Agent"
 description: "Build AI-powered research agents that conduct deep, exploratory interviews using ethnographic techniques to uncover unexpected insights."
 date: "2025-11-04"
 tags: ["interviewer-agent", "qualitative-research", "exploratory-research", "how-to"]
-nav_order: 8
+nav_order: 6
 nav_display: true
 ---
 

--- a/content/docs/guide/running-programs/embed-interviews.md
+++ b/content/docs/guide/running-programs/embed-interviews.md
@@ -3,7 +3,7 @@ title: "Embed Interviews on Your Website or App"
 description: "Deploy Perspective AI interviews directly on your website, in your app, or on landing pages using customizable embed options."
 date: "2025-12-11"
 tags: ["embed", "integration", "deployment", "website"]
-nav_order: 11
+nav_order: 10
 nav_display: true
 ---
 

--- a/content/docs/guide/running-programs/index.md
+++ b/content/docs/guide/running-programs/index.md
@@ -7,24 +7,24 @@ Keep your research or concierge programs humming. These articles cover agent set
 
 ## Create & Configure
 
-- [Create Research Outlines](/docs/guide/getting-started/create-research-outlines)
-- [Use Link Summaries](/docs/guide/running-programs/link-summaries)
-- [Add Form Fields](/docs/guide/running-programs/add-form-fields)
-- [Control Interviews with URL Parameters](/docs/guide/running-programs/url-parapeters)
-- [Build Completion Flows](/docs/guide/running-programs/completion-flows)
+- [Creating Research Outlines](/docs/guide/getting-started/create-research-outlines)
+- [How To Use Link Summaries](/docs/guide/running-programs/link-summaries)
+- [Adding Form Fields to Research Outlines](/docs/guide/running-programs/add-form-fields)
+- [Using URL Parameters to Customize Interviews](/docs/guide/running-programs/url-parapeters)
+- [Creating Completion Flows for Conditional Routing](/docs/guide/running-programs/completion-flows)
 
 ## Agent Types
 
 - [Understanding Agent Types](/docs/guide/running-programs/understanding-agent-types)
-- [Create an Interviewer Agent](/docs/guide/running-programs/creating-interviewer-agent)
-- [Create a Concierge Agent](/docs/guide/running-programs/creating-concierge-agent)
-- [Create an Evaluator Agent](/docs/guide/running-programs/creating-evaluator-agent)
+- [Creating an Interviewer Agent](/docs/guide/running-programs/creating-interviewer-agent)
+- [Creating a Concierge Agent](/docs/guide/running-programs/creating-concierge-agent)
+- [Creating an Evaluator Agent](/docs/guide/running-programs/creating-evaluator-agent)
 
 ## Recruit & Deploy
 
-- [Manage Participant Groups](/docs/guide/running-programs/create-participant-groups)
+- [Creating and Managing Participant Groups](/docs/guide/running-programs/create-participant-groups)
 - [Invite Participants](/docs/guide/getting-started/invite-participants)
-- [Embed Interviews in Your Product](/docs/guide/running-programs/embed-interviews)
-- [Sync Status with User Interviews](/docs/guide/running-programs/sync-status-with-user-interviews)
+- [Embed Interviews on Your Website or App](/docs/guide/running-programs/embed-interviews)
+- [Integrating Perspective AI with User Interviews](/docs/guide/running-programs/sync-status-with-user-interviews)
 
 Use these playbooks whenever you expand a program, add a new channel, or hand off ownership to another team.

--- a/content/docs/guide/running-programs/link-summaries.md
+++ b/content/docs/guide/running-programs/link-summaries.md
@@ -3,7 +3,7 @@ title: "How To Use Link Summaries"
 description: "Learn about link summaries and how they work."
 date: "2023-09-17"
 tags: []
-nav_order: 4
+nav_order: 1
 nav_display: true
 ---
 

--- a/content/docs/guide/running-programs/sync-status-with-user-interviews.md
+++ b/content/docs/guide/running-programs/sync-status-with-user-interviews.md
@@ -3,7 +3,7 @@ title: "Integrating Perspective AI with User Interviews"
 description: "Automatically sync participant statuses between Perspective AI and User Interviews using link parameters to eliminate manual tracking work."
 date: "2025-11-04"
 tags: ["integrations", "user-interviews", "automation", "participant-management"]
-nav_order: 3
+nav_order: 11
 nav_display: true
 ---
 

--- a/content/docs/guide/running-programs/understanding-agent-types.md
+++ b/content/docs/guide/running-programs/understanding-agent-types.md
@@ -1,9 +1,9 @@
 ---
-title: "Understanding Agent Types in Perspective AI"
+title: "Understanding Agent Types"
 description: "Learn about the three agent types—Interviewer, Concierge, and Evaluator—and choose the right one for your use case."
 date: "2025-11-04"
 tags: ["agents", "getting-started", "overview", "agent-types"]
-nav_order: 7
+nav_order: 5
 nav_display: true
 ---
 

--- a/content/docs/guide/running-programs/url-parapeters.md
+++ b/content/docs/guide/running-programs/url-parapeters.md
@@ -3,7 +3,7 @@ title: "Using URL Parameters to Customize Interviews"
 description: "Pass contextual information through URL parameters to personalize interview experiences, enable branching logic, and eliminate repetitive questions."
 date: "2025-11-04"
 tags: ["url-parameters", "customization", "branching-logic", "advanced-features"]
-nav_order: 5
+nav_order: 3
 nav_display: true
 ---
 

--- a/content/docs/guide/whats-new.md
+++ b/content/docs/guide/whats-new.md
@@ -2,6 +2,7 @@
 title: "What's New"
 description: "Rolling change log for Perspective releases."
 nav_order: 99
+nav_display: false
 ---
 
 > Draft structure — populate each release as it ships.
@@ -14,7 +15,7 @@ nav_order: 99
 
 ## How to use this page
 
-1. Keep entries short: *Problem → Improvement → Where to learn more*.
+1. Keep entries short: _Problem → Improvement → Where to learn more_.
 2. Link to docs/examples/training content that explains the change.
 3. Tag the impacted audience (e.g., Product, Dev, Ops).
 4. Archive quarterly into `/archive/` if the list gets too long.

--- a/content/docs/training/index.md
+++ b/content/docs/training/index.md
@@ -9,7 +9,7 @@ Prefer to watch and follow along? Training collects every guided resource — fr
 ## Start learning
 
 - [Video Library](/docs/training/lessons): quick tutorials covering outlines, participant flows, embeds, integrations, and more.
-- [Lesson Catalog](/docs/training/lessons/catalog): durations, owners, and last-updated dates so you know what’s current.
+<!-- - [Lesson Catalog](/docs/training/lessons/catalog): durations, owners, and last-updated dates so you know what’s current. -->
 - **Live workshops & deck downloads** _(coming soon)_: recordings and materials from customer enablement sessions.
 - **Checklists & certifications** _(coming soon)_: printable guides for onboarding new teammates.
 

--- a/content/docs/training/lessons/catalog.md
+++ b/content/docs/training/lessons/catalog.md
@@ -2,6 +2,7 @@
 title: "Lesson Catalog"
 description: "Track every video/tutorial with duration, owner, and last update."
 nav_order: 1
+nav_display: false
 ---
 
 > Draft tracker. Update as you add new lessons so customers can see what’s current.

--- a/content/docs/training/lessons/index.md
+++ b/content/docs/training/lessons/index.md
@@ -1,7 +1,7 @@
 ---
 title: Video Library
 description: Cataloge of training articles.
-nav_order: 6
+nav_order: 1
 ---
 
 Learn Perspective AI through quick, visual tutorials and product demonstrations. Each video is designed to be concise and actionable. Watch, learn, and immediately apply what you've learned to your research projects.
@@ -9,9 +9,10 @@ Learn Perspective AI through quick, visual tutorials and product demonstrations.
 Browse by category below to find step-by-step guides, feature deep-dives, product updates, and company news.
 
 ## Core Features
-- [Create Research Outlines](/docs/training/lessons/create-research-outlines)
-- [Adding Form Fields To Research Outlines](/docs/training/lessons/add-form-fields)
+
+- [How To Create Research Outlines in Perspective AI](/docs/training/lessons/create-research-outlines)
+- [Adding Form Fields to Research Outlines](/docs/training/lessons/add-form-fields)
 - [Inviting Participants to Your Research](/docs/training/lessons/invite-participants)
 - [Integrating Perspective AI with User Interviews](/docs/training/lessons/user-interviews-integration)
-- [Create and Manage Participant Groups](/docs/training/lessons/create-participant-groups)
-- [Create Completion Flows for Conditional Routing](/docs/training/lessons/completion-flows)
+- [Creating and Managing Participant Groups](/docs/training/lessons/create-participant-groups)
+- [Creating Completion Flows for Conditional Routing](/docs/training/lessons/completion-flows)

--- a/content/docs/use-cases/Use-Perspective-AI-to-Collect-Customer-Testimonials-for-VCs.md
+++ b/content/docs/use-cases/Use-Perspective-AI-to-Collect-Customer-Testimonials-for-VCs.md
@@ -3,7 +3,7 @@ title: "How to Use Perspective AI to Collect Customer Testimonials for VCs"
 description: "How to Use Perspective AI to Collect Customer Testimonials for VCs"
 date: "2025-03-28"
 tags: []
-nav_order: 
+nav_order: 14
 nav_display: true
 ---
 

--- a/content/docs/use-cases/accessibility-inclusive-design-guide.md
+++ b/content/docs/use-cases/accessibility-inclusive-design-guide.md
@@ -3,7 +3,7 @@ title: "How to Use Perspective AI for Accessibility & Inclusive Design Research"
 description: "Interview users with disabilities, accessibility advocates, and diverse user groups to understand accessibility barriers, inclusive design requirements, and user experience improvements that make products usable by everyone."
 date: "2025-06-11"
 tags: [accessibility research, inclusive design, disability advocacy, universal design, accessibility barriers]
-nav_order: 20
+nav_order: 23
 nav_display: true
 ---
 

--- a/content/docs/use-cases/ai-focus-groups-guide.md
+++ b/content/docs/use-cases/ai-focus-groups-guide.md
@@ -3,7 +3,7 @@ title: "How to Use AI Focus Groups for Market Research & Product Development Ins
 description: "Conduct scalable focus groups with AI moderation to gather diverse consumer opinions, validate product concepts, and understand market sentiment—revealing customer insights and market opportunities through automated group discussions rather than expensive traditional focus group facilities."
 date: "2025-06-27"
 tags: [ai focus groups, market research, product development, consumer insights, focus group moderation]
-nav_order: 33
+nav_order: 4
 nav_display: true
 ---
 

--- a/content/docs/use-cases/applicant-screening-guide.md
+++ b/content/docs/use-cases/applicant-screening-guide.md
@@ -3,7 +3,7 @@ title: "How to Use Perspective AI for Applicant Screening & Pre-Interview Assess
 description: "Interview job applicants who have applied for positions using structured screening frameworks to gather key qualification information, assess cultural fit, and enable hiring teams to make better interview decisions and improve overall hiring outcomes."
 date: "2025-06-11"
 tags: [applicant screening, pre-interview assessment, hiring qualification, talent screening, recruitment efficiency]
-nav_order: 17
+nav_order: 20
 nav_display: true
 ---
 

--- a/content/docs/use-cases/career-development-planning-guide.md
+++ b/content/docs/use-cases/career-development-planning-guide.md
@@ -3,7 +3,7 @@ title: "How to Use Perspective AI for Career Development & Growth Planning"
 description: "Develop self-reflection interviews that help you assess your career satisfaction, identify skill gaps, explore growth opportunities, and plan strategic career moves based on honest self-assessment."
 date: "2025-06-11"
 tags: [career development, career planning, professional growth, self-assessment, career reflection]
-nav_order: 29
+nav_order: 31
 nav_display: true
 ---
 

--- a/content/docs/use-cases/churn-analysis-guide.md
+++ b/content/docs/use-cases/churn-analysis-guide.md
@@ -3,7 +3,7 @@ title: "How to Use Perspective AI for Churn Analysis & Customer Exit Interviews"
 description: "Interview recently churned customers directly to understand their specific cancellation reasons, identify systemic issues, and develop targeted retention strategies based on actual churn experiences rather than assumptions."
 date: "2025-06-11"
 tags: [churn analysis, customer exit interviews, customer retention, customer success, churn prevention]
-nav_order: 13
+nav_order: 15
 nav_display: true
 ---
 

--- a/content/docs/use-cases/customer-journey-mapping-guide.md
+++ b/content/docs/use-cases/customer-journey-mapping-guide.md
@@ -3,7 +3,7 @@ title: "How to Use Perspective AI for Customer Journey Mapping & Experience Opti
 description: "Interview customers across different journey stages to understand their end-to-end experience, identify pain points and moments of delight, and optimize touchpoints for better customer satisfaction and business outcomes."
 date: "2025-06-11"
 tags: [customer journey mapping, customer experience, CX optimization, touchpoint analysis, customer satisfaction]
-nav_order: 21
+nav_order: 24
 nav_display: true
 ---
 

--- a/content/docs/use-cases/customer-loyalty-retention-guide.md
+++ b/content/docs/use-cases/customer-loyalty-retention-guide.md
@@ -3,7 +3,7 @@ title: "How to Use Perspective AI for Customer Loyalty & Retention Strategy"
 description: "Interview long-term customers, recently churned customers, and at-risk customers to understand loyalty drivers, retention barriers, and emotional engagement factors that inform loyalty strategy and retention initiatives."
 date: "2025-06-11"
 tags: [customer loyalty, customer retention, loyalty strategy, customer engagement, retention analysis]
-nav_order: 24
+nav_order: 26
 nav_display: true
 ---
 

--- a/content/docs/use-cases/customer-onboarding-optimization-guide.md
+++ b/content/docs/use-cases/customer-onboarding-optimization-guide.md
@@ -3,7 +3,7 @@ title: "How to Use Perspective AI for Customer Onboarding & Time-to-Value Optimi
 description: "Conduct interviews with new customers, successful adopters, and those who struggled during onboarding to identify friction points, accelerate value realization, and improve customer success outcomes."
 date: "2025-06-11"
 tags: [customer onboarding, time to value, customer success, onboarding optimization, customer adoption]
-nav_order: 14
+nav_order: 16
 nav_display: true
 ---
 

--- a/content/docs/use-cases/customer-support-experience-guide.md
+++ b/content/docs/use-cases/customer-support-experience-guide.md
@@ -3,7 +3,7 @@ title: "How to Use Perspective AI for Customer Support & Service Experience Enha
 description: "Interview customers who have recently interacted with support to understand their service experience, identify support process improvements, and optimize service delivery for better customer outcomes and operational efficiency."
 date: "2025-06-11"
 tags: [customer support, service experience, support optimization, customer service, service delivery]
-nav_order: 25
+nav_order: 27
 nav_display: true
 ---
 

--- a/content/docs/use-cases/design-system-adoption-guide.md
+++ b/content/docs/use-cases/design-system-adoption-guide.md
@@ -3,7 +3,7 @@ title: "How to Use Perspective AI for Design System Adoption & Usage Analysis"
 description: "Interview designers, developers, and product teams to understand design system usage patterns, identify adoption barriers, and optimize design system strategy for better consistency and efficiency across the organization."
 date: "2025-06-11"
 tags: [design system, design operations, design consistency, team collaboration, design adoption]
-nav_order: 19
+nav_order: 22
 nav_display: true
 ---
 

--- a/content/docs/use-cases/digital-transformation-guide.md
+++ b/content/docs/use-cases/digital-transformation-guide.md
@@ -3,7 +3,7 @@ title: "How to Use Perspective AI for Digital Transformation & Technology Strate
 description: "Conduct interviews with internal stakeholders, technology users, and transformation leaders to understand current pain points, technology readiness, and change management requirements for successful digital transformation initiatives."
 date: "2025-06-11"
 tags: [digital transformation, technology strategy, change management, IT strategy, innovation management]
-nav_order: 9
+nav_order: 10
 nav_display: true
 ---
 

--- a/content/docs/use-cases/employee-feedback-guide.md
+++ b/content/docs/use-cases/employee-feedback-guide.md
@@ -3,7 +3,7 @@ title: "How to Use Perspective AI to Collect and Analyze Employee Feedback"
 description: "Transform scattered employee feedback into clear, actionable insights using AI-powered interviews that gather consistent, in-depth feedback and automatically analyze it for patterns, sentiment, and priority areas."
 date: "2025-06-11"
 tags: [employee feedback, HR analytics, workplace satisfaction, employee interviews, retention analysis]
-nav_order: 
+nav_order: 18
 nav_display: true
 ---
 

--- a/content/docs/use-cases/expansion-upsell-guide.md
+++ b/content/docs/use-cases/expansion-upsell-guide.md
@@ -3,7 +3,7 @@ title: "How to Use Perspective AI for Expansion & Upsell Opportunity Identificat
 description: "Interview existing customers to understand their evolving needs, expansion triggers, and growth opportunities that align customer success with revenue expansion through value-driven upselling."
 date: "2025-06-11"
 tags: [customer expansion, upsell opportunities, account growth, customer success, revenue expansion]
-nav_order: 15
+nav_order: 17
 nav_display: true
 ---
 

--- a/content/docs/use-cases/feature-prioritization-guide.md
+++ b/content/docs/use-cases/feature-prioritization-guide.md
@@ -3,7 +3,7 @@ title: "How to Use Perspective AI for Feature Prioritization & Roadmap Validatio
 description: "Replace feature request chaos with systematic customer interviews that reveal true priorities, usage context, and willingness to pay for different capabilities to build data-driven product roadmaps."
 date: "2025-06-11"
 tags: [feature prioritization, product roadmap, product management, customer interviews, product validation]
-nav_order: 4
+nav_order: 5
 nav_display: true
 ---
 

--- a/content/docs/use-cases/index.md
+++ b/content/docs/use-cases/index.md
@@ -13,43 +13,63 @@ Each guide follows our proven 7-step methodology: Define your research question,
 Choose your use case below to get started:
 
 ## Market Research
+
 - [How to Use Perspective AI for Competitive Intelligence & Market Positioning](/docs/use-cases/competitive-intelligence-guide)
 - [How to Use Perspective AI for Customer Persona Development & Validation](/docs/use-cases/customer-persona-guide)
 - [How to Use Perspective AI for Product-Market Fit Assessment](/docs/use-cases/product-market-fit-guide)
 - [How to Use AI Focus Groups for Market Research & Product Development Insights](/docs/use-cases/ai-focus-groups-guide)
+
 ## Product Management
+
 - [How to Use Perspective AI for Feature Prioritization & Roadmap Validation](/docs/use-cases/feature-prioritization-guide)
 - [How to Use Perspective AI for User Onboarding & Activation Optimization](/docs/use-cases/user-onboarding-guide)
 - [How to Use Perspective AI for Product-Led Growth & Expansion Strategy](/docs/use-cases/product-led-growth-guide)
+
 ## Strategy
+
 - [How to Use Perspective AI for Market Entry & Expansion Strategy](/docs/use-cases/market-entry-guide)
 - [How to Use Perspective AI for Strategic Partnership & Channel Strategy](/docs/use-cases/strategic-partnership-guide)
 - [How to Use Perspective AI for Digital Transformation & Technology Strategy](/docs/use-cases/digital-transformation-guide)
+
 ## Sales
+
 - [How to Use Perspective AI for Win/Loss Analysis & Competitive Positioning](/docs/use-cases/win-loss-analysis-guide)
 - [How to Use Perspective AI for Sales Demo & Call Preparation](/docs/use-cases/sales-demo-prep-guide)
 - [How to Use Perspective AI for Sales Process Optimization & Deal Acceleration](/docs/use-cases/sales-process-optimization-guide)
+- [How to Use Perspective AI to Collect Customer Testimonials for VCs](/docs/use-cases/Use-Perspective-AI-to-Collect-Customer-Testimonials-for-VCs)
+
 ## Customer Success
+
 - [How to Use Perspective AI for Churn Analysis & Customer Exit Interviews](/docs/use-cases/churn-analysis-guide)
 - [How to Use Perspective AI for Customer Onboarding & Time-to-Value Optimization](/docs/use-cases/customer-onboarding-optimization-guide)
 - [How to Use Perspective AI for Expansion & Upsell Opportunity Identification](/docs/use-cases/expansion-upsell-guide)
+
 ## Human Resources
+
 - [How to Use Perspective AI to Collect and Analyze Employee Feedback](/docs/use-cases/employee-feedback-guide)
 - [How to Use Perspective AI for Recruitment & Hiring Process Optimization](/docs/use-cases/recruitment-optimization-guide)
 - [How to Use Perspective AI for Applicant Screening & Pre-Interview Assessment](/docs/use-cases/applicant-screening-guide)
+
 ## Design
+
 - [How to Use Perspective AI for User Experience Research & Design Validation](/docs/use-cases/ux-research-validation-guide)
 - [How to Use Perspective AI for Design System Adoption & Usage Analysis](/docs/use-cases/design-system-adoption-guide)
 - [How to Use Perspective AI for Accessibility & Inclusive Design Research](/docs/use-cases/accessibility-inclusive-design-guide)
+
 ## Customer Experience
+
 - [How to Use Perspective AI for Customer Journey Mapping & Experience Optimization](/docs/use-cases/customer-journey-mapping-guide)
 - [How to Use Perspective AI for Voice of Customer Analysis & Feedback Integration](/docs/use-cases/voice-of-customer-guide)
 - [How to Use Perspective AI for Customer Loyalty & Retention Strategy](/docs/use-cases/customer-loyalty-retention-guide)
+
 ## Customer Support
+
 - [How to Use Perspective AI for Customer Support & Service Experience Enhancement](/docs/use-cases/customer-support-experience-guide)
 - [How to Use Perspective AI for Support Knowledge Management & Self-Service Optimization](/docs/use-cases/support-knowledge-management-guide)
 - [How to Use Perspective AI for Support Escalation & Complex Case Management](/docs/use-cases/support-escalation-management-guide)
-## Personal Relfection
+
+## Personal Reflection
+
 - [How to Use Perspective AI for Weekly/Monthly Performance & Goal Review](/docs/use-cases/weekly-performance-review-guide)
 - [How to Use Perspective AI for Career Development & Growth Planning](/docs/use-cases/career-development-planning-guide)
 - [How to Use Perspective AI for Life Transition & Decision-Making Support](/docs/use-cases/life-transition-decision-guide)

--- a/content/docs/use-cases/life-transition-decision-guide.md
+++ b/content/docs/use-cases/life-transition-decision-guide.md
@@ -3,7 +3,7 @@ title: "How to Use Perspective AI for Life Transition & Decision-Making Support"
 description: "Create guided self-reflection processes that help you clarify your values, assess options, understand your motivations, and make confident decisions during significant life transitions."
 date: "2025-06-11"
 tags: [life transitions, decision making, personal reflection, life planning, major decisions]
-nav_order: 30
+nav_order: 32
 nav_display: true
 ---
 

--- a/content/docs/use-cases/market-entry-guide.md
+++ b/content/docs/use-cases/market-entry-guide.md
@@ -3,7 +3,7 @@ title: "How to Use Perspective AI for Market Entry & Expansion Strategy"
 description: "Replace market entry assumptions with systematic interviews of potential customers, partners, and industry experts to validate opportunity size, competitive landscape, and go-to-market approach for successful market expansion."
 date: "2025-06-11"
 tags: [market entry, expansion strategy, strategic planning, market research, business development]
-nav_order: 7
+nav_order: 8
 nav_display: true
 ---
 

--- a/content/docs/use-cases/product-led-growth-guide.md
+++ b/content/docs/use-cases/product-led-growth-guide.md
@@ -3,7 +3,7 @@ title: "How to Use Perspective AI for Product-Led Growth & Expansion Strategy"
 description: "Understand how customers naturally expand usage, share products with colleagues, and upgrade to higher tiers through interviews with power users and decision-makers to design product experiences that drive organic growth."
 date: "2025-06-11"
 tags: [product-led growth, expansion strategy, account expansion, viral growth, product management]
-nav_order: 6
+nav_order: 7
 nav_display: true
 ---
 

--- a/content/docs/use-cases/recruitment-optimization-guide.md
+++ b/content/docs/use-cases/recruitment-optimization-guide.md
@@ -3,7 +3,7 @@ title: "How to Use Perspective AI for Recruitment & Hiring Process Optimization"
 description: "Interview recent hires, candidates who declined offers, and those who went through the hiring process to identify friction points, understand decision factors, and optimize recruitment strategies for better hiring outcomes and candidate satisfaction."
 date: "2025-06-11"
 tags: [recruitment optimization, hiring process, candidate experience, talent acquisition, HR optimization]
-nav_order: 16
+nav_order: 19
 nav_display: true
 ---
 

--- a/content/docs/use-cases/sales-demo-prep-guide.md
+++ b/content/docs/use-cases/sales-demo-prep-guide.md
@@ -3,7 +3,7 @@ title: "How to Use Perspective AI for Sales Demo & Call Preparation"
 description: "Interview prospects who have scheduled sales calls using standard qualification frameworks (BANT, MEDDIC) to gather key information that enables sales teams to customize their pitch, demo, and approach for higher conversion rates."
 date: "2025-06-11"
 tags: [sales demo preparation, call prep, sales qualification, BANT, MEDDIC, sales enablement]
-nav_order: 11
+nav_order: 12
 nav_display: true
 ---
 

--- a/content/docs/use-cases/sales-process-optimization-guide.md
+++ b/content/docs/use-cases/sales-process-optimization-guide.md
@@ -3,7 +3,7 @@ title: "How to Use Perspective AI for Sales Process Optimization & Deal Accelera
 description: "Interview prospects, customers, and internal sales teams to identify friction points in the sales process, understand buyer decision-making patterns, and optimize deal progression strategies for shorter cycles and higher win rates."
 date: "2025-06-11"
 tags: [sales process optimization, deal acceleration, sales cycle, buyer journey, sales operations]
-nav_order: 12
+nav_order: 13
 nav_display: true
 ---
 

--- a/content/docs/use-cases/strategic-partnership-guide.md
+++ b/content/docs/use-cases/strategic-partnership-guide.md
@@ -3,7 +3,7 @@ title: "How to Use Perspective AI for Strategic Partnership & Channel Strategy"
 description: "Interview existing partners, potential partners, and customers to understand partnership needs, evaluate channel opportunities, and design mutually beneficial strategic relationships that drive business growth."
 date: "2025-06-11"
 tags: [strategic partnerships, channel strategy, business development, partnership management, channel optimization]
-nav_order: 8
+nav_order: 9
 nav_display: true
 ---
 

--- a/content/docs/use-cases/support-escalation-management-guide.md
+++ b/content/docs/use-cases/support-escalation-management-guide.md
@@ -3,7 +3,7 @@ title: "How to Use Perspective AI for Support Escalation & Complex Case Manageme
 description: "Interview customers with escalated cases, support agents handling complex issues, and escalation specialists to understand process effectiveness, identify improvement opportunities, and optimize case management for better outcomes."
 date: "2025-06-11"
 tags: [support escalation, complex case management, customer support, escalation process, case resolution]
-nav_order: 27
+nav_order: 29
 nav_display: true
 ---
 

--- a/content/docs/use-cases/support-knowledge-management-guide.md
+++ b/content/docs/use-cases/support-knowledge-management-guide.md
@@ -3,7 +3,7 @@ title: "How to Use Perspective AI for Support Knowledge Management & Self-Servic
 description: "Interview customers who use self-service resources and support agents who rely on knowledge systems to identify content gaps, usability issues, and optimization opportunities that improve both customer self-service success and agent efficiency."
 date: "2025-06-11"
 tags: [knowledge management, self-service, support optimization, knowledge base, customer service]
-nav_order: 26
+nav_order: 28
 nav_display: true
 ---
 

--- a/content/docs/use-cases/user-onboarding-guide.md
+++ b/content/docs/use-cases/user-onboarding-guide.md
@@ -3,7 +3,7 @@ title: "How to Use Perspective AI for User Onboarding & Activation Optimization"
 description: "Identify onboarding friction points, activation barriers, and 'aha moments' through interviews with new users, successful adopters, and those who churned during onboarding to optimize user activation."
 date: "2025-06-11"
 tags: [user onboarding, activation optimization, product management, user experience, customer success]
-nav_order: 5
+nav_order: 6
 nav_display: true
 ---
 

--- a/content/docs/use-cases/ux-research-validation-guide.md
+++ b/content/docs/use-cases/ux-research-validation-guide.md
@@ -3,7 +3,7 @@ title: "How to Use Perspective AI for User Experience Research & Design Validati
 description: "Interview users, stakeholders, and customers to gather feedback on design concepts, prototypes, and existing interfaces—revealing usability issues, user preferences, and design improvement opportunities based on real user behavior rather than assumptions."
 date: "2025-06-11"
 tags: [user experience research, design validation, UX research, usability testing, design feedback]
-nav_order: 18
+nav_order: 21
 nav_display: true
 ---
 

--- a/content/docs/use-cases/voice-of-customer-guide.md
+++ b/content/docs/use-cases/voice-of-customer-guide.md
@@ -3,7 +3,7 @@ title: "How to Use Perspective AI for Voice of Customer Analysis & Feedback Inte
 description: "Conduct structured interviews with customers to gather comprehensive feedback about their experience, understand satisfaction drivers, and translate insights into actionable CX improvements that address real customer needs."
 date: "2025-06-11"
 tags: [voice of customer, customer feedback, CX analysis, customer insights, feedback integration]
-nav_order: 22
+nav_order: 25
 nav_display: true
 ---
 

--- a/content/docs/use-cases/weekly-performance-review-guide.md
+++ b/content/docs/use-cases/weekly-performance-review-guide.md
@@ -3,7 +3,7 @@ title: "How to Use Perspective AI for Weekly/Monthly Performance & Goal Review"
 description: "Create structured self-interview guides that help you reflect on accomplishments, challenges, goal progress, and lessons learned to organize thoughts and create actionable insights for continuous improvement."
 date: "2025-06-11"
 tags: [personal reflection, performance review, goal tracking, self-assessment, productivity]
-nav_order: 28
+nav_order: 30
 nav_display: true
 ---
 

--- a/content/docs/use-cases/win-loss-analysis-guide.md
+++ b/content/docs/use-cases/win-loss-analysis-guide.md
@@ -3,7 +3,7 @@ title: "How to Use Perspective AI for Win/Loss Analysis & Competitive Positionin
 description: "Systematically interview recent prospects (both wins and losses) to understand decision factors, competitive advantages/disadvantages, and positioning opportunities that improve close rates and sales effectiveness."
 date: "2025-06-11"
 tags: [win loss analysis, competitive positioning, sales optimization, deal analysis, sales enablement]
-nav_order: 10
+nav_order: 11
 nav_display: true
 ---
 


### PR DESCRIPTION
## What's Changed

The docs navigation had accumulated inconsistencies — nav ordering didn't match index page structure, article titles diverged from their index link text, and several draft/placeholder pages were publicly visible. This audit pass brings everything into alignment.

**Navigation Order**
- Fixed `nav_order` values across all sections to match the order articles appear in their parent index (getting-started, running-programs, insights, operations, use-cases)
- Removed duplicate `nav_order: 1` conflict in training/lessons

**Title Consistency**
- Synced article titles with index link text across guide, running-programs, insights, operations, build, examples, training/lessons, and use-cases sections
- Standardised verb forms (imperative vs gerund) across running-programs and training/lessons
- Removed redundant suffixes like "in Perspective AI" and "Guide" from article titles

**Draft & Placeholder Visibility**
- Added `nav_display: false` to draft/placeholder pages (api-overview, automation-recipes, webhooks, billing, data-governance, permissions-roles, whats-new, customer-stories, templates)
- Commented out all index links pointing to hidden pages

**Use Cases**
- Added missing VC Testimonials guide to the Sales section of the use-cases index
- Resequenced all use-case `nav_order` values to match the index's categorical grouping
- Fixed typo: "Personal Relfection" → "Personal Reflection"
